### PR TITLE
[enh] generate manpages from actionsmap

### DIFF
--- a/doc/generate_manpages.py
+++ b/doc/generate_manpages.py
@@ -10,41 +10,130 @@ import os
 import yaml
 import subprocess
 
+from datetime import date
+from collections import OrderedDict
+
+from jinja2 import Template
+
+template = Template('''\
+.TH YunoHost "1" "{{ month }} {{ year }}" "YunoHost Collectif"
+.SH NAME
+YunoHost \\- yunohost server administration command
+.SH SYNOPSIS
+yunohost \\fI\\,CATEGORY\\/\\fR \\fI\\,COMMAND\\/\\fR [\\fI\\,SUBCOMMAND\\/\\fR] [\\fI\\,ARGUMENTS\\/\\fR]... [\\fI\\,OPTIONS\\/\\fR]...
+.SH DESCRIPTION
+usage: yunohost
+{{ '{' }}{{ ",".join(categories) }}{{ '}' }}
+\&...
+[\\-h|\\-\\-help] [\\-\\-no\\-cache] [\\-\\-output\\-as {json,plain,none}] [\\-\\-debug]
+[\\-\\-quiet] [\\-\\-timeout ==SUPPRESS==] [\\-\\-admin\\-password PASSWORD]
+[\\-v|\\-\\-version]
+.SS "optional arguments:"
+.TP
+\\fB\\-h\\fR, \\fB\\-\\-help\\fR
+show this help message and exit
+.SS "categories:"
+.IP
+{{ '{' }}{{ ",".join(categories) }}{{ '}' }}
+{% for name, value in categories.items() %}
+.TP
+{{ name }}
+{{ value["category_help"] }}
+{% endfor %}
+Manage debug logs
+.SS "global arguments:"
+.TP
+\\fB\\-\\-no\\-cache\\fR
+Don't use actions map cache
+.TP
+\\fB\\-\\-output\\-as\\fR {json,plain,none}
+Output result in another format
+.TP
+\\fB\\-\\-debug\\fR
+Log and print debug messages
+.TP
+\\fB\\-\\-quiet\\fR
+Don't produce any output
+.TP
+\\fB\\-\\-timeout\\fR SECONDS
+Number of seconds before this command will timeout
+because it can't acquire the lock (meaning that
+another command is currently running), by default
+there is no timeout and the command will wait until it
+can get the lock
+.TP
+\\fB\\-\\-admin\\-password\\fR PASSWORD
+The admin password to use to authenticate
+.TP
+\\fB\\-v\\fR, \\fB\\-\\-version\\fR
+Display YunoHost packages versions
+{% for name, value in categories.items() %}
+.SH YUNOHOST {{ name.upper() }}
+usage: yunohost {{ name }} {{ '{' }}{{ ",".join(value["actions"].keys()) }}{{ '}' }}
+\\&...
+.SS "description:"
+.IP
+{{ value["category_help"] }}
+{% for action, action_value in value["actions"].items() %}
+.SS "yunohost {{ name }} {{ action }} \
+{% for argument_name, argument_value in action_value.get("arguments", {}).items() %}\
+{% set required=(not str(argument_name).startswith("-")) or argument_value.get("extra", {}).get("required", False) %}\
+{% if not required %}[{% endif %}\
+\\fI\\,{{ argument_name }}\\/\\fR{% if argument_value.get("full") %}|\\fI\\,{{ argument_value["full"] }}\\fR{% endif %}\
+{% if str(argument_name).startswith("-") and not argument_value.get("action") == "store_true" %} {{ (argument_value.get("full", argument_name)).lstrip("-") }}{% endif %}\
+{% if not required %}]{% endif %} \
+{% endfor %}"
+{{ action_value["action_help"] }}
+{% if "arguments" in action_value %}
+{% for argument_name, argument_value in action_value["arguments"].items() %}
+.TP
+\\fB{{ argument_name }}\\fR{% if argument_value.get("full") %}, \\fB{{ argument_value["full"] }}\\fR{% endif %}\
+{% if str(argument_name).startswith("-") and not argument_value.get("action") == "store_true" %} \\fI\\,{{ (argument_value.get("full", argument_name)).lstrip("-") }}\\fR{% endif %}
+{{ argument_value.get("help", "")}}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endfor %}
+''')
+
 
 THIS_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 ACTIONSMAP_FILE = os.path.join(THIS_SCRIPT_DIR, '../data/actionsmap/yunohost.yml')
 OUTPUT_DIR = "output/"
+
+
+def ordered_yaml_load(stream):
+    class OrderedLoader(yaml.Loader):
+        pass
+    OrderedLoader.add_constructor(
+        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+        lambda loader, node: OrderedDict(loader.construct_pairs(node)))
+    return yaml.load(stream, OrderedLoader)
+
 
 # creates output directory
 if not os.path.exists(OUTPUT_DIR):
     os.makedirs(OUTPUT_DIR)
 
 
-# man page of yunohost
-cmd = "sudo help2man \" yunohost \" -o " + OUTPUT_DIR + "yunohost"
-print(cmd)
-subprocess.check_call(cmd, shell=True)
-
 # man pages of "yunohost *"
-with open(ACTIONSMAP_FILE, 'r') as stream:
+with open(ACTIONSMAP_FILE, 'r') as actionsmap:
 
     # Getting the dictionary containning what actions are possible per domain
-    OPTION_TREE = yaml.safe_load(stream)
+    actionsmap = ordered_yaml_load(actionsmap)
 
-    DOMAINS = [x for x in OPTION_TREE.keys() if not x.startswith('_')]
-    DOMAINS_STR = '"{}"'.format(' '.join(DOMAINS))
+    for i in actionsmap.keys():
+        if i.startswith("_"):
+            del actionsmap[i]
 
-    ACTIONS_DICT = {}
+    today = date.today()
 
-    for domain in DOMAINS:
-        ACTIONS = [str for str in OPTION_TREE[domain]['actions'].keys()
-                   if not str.startswith('_')]
+    result = template.render(
+        month=today.strftime("%B"),
+        year=today.year,
+        categories=actionsmap,
+        str=str,
+    )
 
-        ACTIONS_STR = '"{}"'.format(' '.join(ACTIONS))
-        ACTIONS_DICT[domain] = ACTIONS_STR
-
-        for action in ACTIONS:
-            # print("yunohost", domain, action)
-            cmd = "sudo help2man \" yunohost " + domain + "  " + action + " --help \" -o " + OUTPUT_DIR + "yunohost_" + domain + "_" + action
-            print(cmd)
-            subprocess.check_call(cmd, shell=True)
+with open(os.path.join(OUTPUT_DIR, "yunohost"), "w") as output:
+    output.write(result)


### PR DESCRIPTION
## The problem

Continuing the work on https://github.com/YunoHost/yunohost/pull/682, we prefer a "only one page" approach (or maybe a page per category but not per command.)

Also you can't generate those manpages if yunohost isn't post-isntall with the previous approach.

Sample:
![2019-04-29-234231_1107x1001_scrot](https://user-images.githubusercontent.com/41827/56928911-80ece600-6ad8-11e9-8899-f821f70d2aa8.png)

## Solution

Generate everything from `actionsmap.yaml`

## PR Status

Working prototype but missing things are:

* default arguments
* nargs support
* subcommands

## How to test

    python generate_manpages.py && man -l output/yunohost

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
